### PR TITLE
Add support to MiniMessage formatting in item displayName & lore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>PaperSpec</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
   <packaging>jar</packaging>
 
   <name>PaperSpec</name>
@@ -34,9 +34,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.destroystokyo.paper</groupId>
+      <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.12.2-R0.1-SNAPSHOT</version>
+      <version>1.19.3-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/me/hsgamer/bettergui/paperspec/PaperSpec.java
+++ b/src/main/java/me/hsgamer/bettergui/paperspec/PaperSpec.java
@@ -1,18 +1,35 @@
 package me.hsgamer.bettergui.paperspec;
 
 import me.hsgamer.bettergui.builder.ItemModifierBuilder;
+import me.hsgamer.bettergui.paperspec.modifier.AdventureLoreModifier;
+import me.hsgamer.bettergui.paperspec.modifier.AdventureNameModifier;
 import me.hsgamer.bettergui.paperspec.modifier.PaperSkullModifier;
 import me.hsgamer.hscore.bukkit.addon.PluginAddon;
 import me.hsgamer.hscore.common.Validate;
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
 
 public final class PaperSpec extends PluginAddon {
     @Override
     public boolean onLoad() {
-        return Validate.isClassLoaded("com.destroystokyo.paper.PaperConfig") || Validate.isClassLoaded("io.papermc.paper.configuration.Configuration");
+        return (Validate.isClassLoaded("com.destroystokyo.paper.PaperConfig") ||
+                Validate.isClassLoaded("io.papermc.paper.configuration.Configuration")
+               ) &&
+               (Validate.isClassLoaded("net.kyori.adventure.text.Component") &&
+                Validate.isClassLoaded("net.kyori.adventure.text.minimessage.MiniMessage") &&
+                Validate.isClassLoaded("net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer") &&
+                Validate.isMethodLoaded("org.bukkit.inventory.meta.ItemMeta", "lore", List.class) &&
+                Validate.isMethodLoaded("org.bukkit.inventory.meta.ItemMeta", "lore") &&
+                Validate.isMethodLoaded("org.bukkit.inventory.meta.ItemMeta", "displayName", Component.class) &&
+                Validate.isMethodLoaded("org.bukkit.inventory.meta.ItemMeta", "displayName")
+               );
     }
 
     @Override
     public void onEnable() {
         ItemModifierBuilder.INSTANCE.register(PaperSkullModifier::new, "paper-skull", "paper-head");
+        ItemModifierBuilder.INSTANCE.register(AdventureNameModifier::new, "mini-name", "adventure-name", "name$");
+        ItemModifierBuilder.INSTANCE.register(AdventureLoreModifier::new, "mini-lore", "adventure-lore", "lore$");
     }
 }

--- a/src/main/java/me/hsgamer/bettergui/paperspec/modifier/AdventureLoreModifier.java
+++ b/src/main/java/me/hsgamer/bettergui/paperspec/modifier/AdventureLoreModifier.java
@@ -1,0 +1,118 @@
+package me.hsgamer.bettergui.paperspec.modifier;
+
+import me.hsgamer.bettergui.paperspec.util.AdventureUtils;
+import me.hsgamer.hscore.bukkit.item.ItemMetaModifier;
+import me.hsgamer.hscore.common.CollectionUtils;
+import me.hsgamer.hscore.common.interfaces.StringReplacer;
+import net.kyori.adventure.text.Component;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+
+import java.util.*;
+
+public class AdventureLoreModifier extends ItemMetaModifier {
+    private final List<String> lore = new ArrayList<>(); // Stored as MiniMessage representation
+
+    @Override
+    public String getName() {
+        return "adventure-lore";
+    }
+
+    private List<String> getReplacedLore(UUID uuid, Map<String, StringReplacer> stringReplacerMap) {
+        List<String> replacedLore = new ArrayList<>(lore);
+        replacedLore.replaceAll(s -> StringReplacer.replace(s, uuid, stringReplacerMap.values()));
+        return replacedLore;
+    }
+
+    @Override
+    public ItemMeta modifyMeta(ItemMeta meta, UUID uuid, Map<String, StringReplacer> stringReplacerMap) {
+        List<Component> lore = AdventureUtils.toComponent(getReplacedLore(uuid, stringReplacerMap));
+        List<Component> noItalic = AdventureUtils.disableItalic(lore);
+        meta.lore(noItalic);
+        return meta;
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public void loadFromItemMeta(ItemMeta meta) {
+        setLore(AdventureUtils.toMiniMessage(meta.lore()));
+    }
+
+    @Override
+    public boolean canLoadFromItemMeta(ItemMeta meta) {
+        return meta.hasLore();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public boolean compareWithItemMeta(ItemMeta meta, UUID uuid, Map<String, StringReplacer> stringReplacerMap) {
+        if (!meta.hasLore() && this.lore.isEmpty()) {
+            return true;
+        }
+
+        // Since text components are complex, we compare the plain text representation for equality
+        List<String> plainText1 = AdventureUtils.stripTags(getReplacedLore(uuid, stringReplacerMap));
+        List<String> plainText2 = AdventureUtils.toPlainText(meta.lore());
+        return plainText1.equals(plainText2);
+    }
+
+    @Override
+    public Object toObject() {
+        return lore;
+    }
+
+    @Override
+    public void loadFromObject(Object object) {
+        setLore(CollectionUtils.createStringListFromObject(object, false));
+    }
+
+    /**
+     * Set the lore
+     *
+     * @param lore the lore
+     *
+     * @return {@code this} for builder chain
+     */
+    @Contract("_ -> this")
+    public AdventureLoreModifier setLore(String... lore) {
+        return setLore(Arrays.asList(lore));
+    }
+
+    /**
+     * Add a lore
+     *
+     * @param lore the lore
+     *
+     * @return {@code this} for builder chain
+     */
+    @Contract("_ -> this")
+    public AdventureLoreModifier addLore(String lore) {
+        this.lore.addAll(Arrays.asList(lore.split("\\n")));
+        return this;
+    }
+
+    /**
+     * Set the lore
+     *
+     * @param lore the lore
+     *
+     * @return {@code this} for builder chain
+     */
+    @Contract("_ -> this")
+    public AdventureLoreModifier setLore(Collection<String> lore) {
+        clearLore();
+        this.lore.addAll(CollectionUtils.splitAll("\\n", lore));
+        return this;
+    }
+
+    /**
+     * Clear the lore
+     *
+     * @return {@code this} for builder chain
+     */
+    @Contract(" -> this")
+    public AdventureLoreModifier clearLore() {
+        this.lore.clear();
+        return this;
+    }
+}

--- a/src/main/java/me/hsgamer/bettergui/paperspec/modifier/AdventureNameModifier.java
+++ b/src/main/java/me/hsgamer/bettergui/paperspec/modifier/AdventureNameModifier.java
@@ -1,0 +1,77 @@
+package me.hsgamer.bettergui.paperspec.modifier;
+
+import me.hsgamer.bettergui.paperspec.util.AdventureUtils;
+import me.hsgamer.hscore.bukkit.item.ItemMetaModifier;
+import me.hsgamer.hscore.common.interfaces.StringReplacer;
+import net.kyori.adventure.text.Component;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class AdventureNameModifier extends ItemMetaModifier {
+    private String name; // Stored as MiniMessage representation
+
+    @Override
+    public String getName() {
+        return "adventure-name";
+    }
+
+    /**
+     * Set the name
+     *
+     * @param name the name in MiniMessage representation
+     *
+     * @return {@code this} for builder chain
+     */
+    @Contract("_ -> this")
+    public AdventureNameModifier setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public ItemMeta modifyMeta(ItemMeta meta, UUID uuid, Map<String, StringReplacer> stringReplacerMap) {
+        Component displayName = AdventureUtils.toComponent(StringReplacer.replace(name, uuid, stringReplacerMap.values()));
+        Component noItalic = AdventureUtils.disableItalic(displayName);
+        meta.displayName(noItalic);
+        return meta;
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public void loadFromItemMeta(ItemMeta meta) {
+        this.name = AdventureUtils.toMiniMessage(meta.displayName());
+    }
+
+    @Override
+    public boolean canLoadFromItemMeta(ItemMeta meta) {
+        return meta.hasDisplayName();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public boolean compareWithItemMeta(ItemMeta meta, UUID uuid, Map<String, StringReplacer> stringReplacerMap) {
+        String replaced = StringReplacer.replace(this.name, uuid, stringReplacerMap.values());
+
+        if (!meta.hasDisplayName() && replaced == null) {
+            return true;
+        }
+
+        // Since text components are complex, we compare the plain text representation for equality
+        String plainText1 = AdventureUtils.stripTags(replaced);
+        String plainText2 = AdventureUtils.toPlainText(meta.displayName());
+        return plainText1.equals(plainText2);
+    }
+
+    @Override
+    public Object toObject() {
+        return this.name;
+    }
+
+    @Override
+    public void loadFromObject(Object object) {
+        this.name = String.valueOf(object);
+    }
+}

--- a/src/main/java/me/hsgamer/bettergui/paperspec/util/AdventureUtils.java
+++ b/src/main/java/me/hsgamer/bettergui/paperspec/util/AdventureUtils.java
@@ -1,0 +1,60 @@
+package me.hsgamer.bettergui.paperspec.util;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextDecorationAndState;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AdventureUtils {
+
+    private static final TextDecorationAndState ITALIC_OFF = TextDecoration.ITALIC.withState(TextDecoration.State.FALSE);
+
+    @Contract(pure = true)
+    public static @NotNull Component disableItalic(@NotNull Component component) {
+        return component.applyFallbackStyle(ITALIC_OFF);
+    }
+
+    @Contract(pure = true)
+    public static @NotNull List<Component> disableItalic(@NotNull List<Component> componentList) {
+        return componentList.stream().map(AdventureUtils::disableItalic).collect(Collectors.toList());
+    }
+
+    public static @NotNull Component toComponent(@NotNull String mini) {
+        return MiniMessage.miniMessage().deserialize(mini);
+    }
+
+    public static @NotNull List<Component> toComponent(@NotNull List<String> miniList) {
+        return miniList.stream().map(AdventureUtils::toComponent).collect(Collectors.toList());
+    }
+
+    public static @NotNull String toMiniMessage(@NotNull Component component) {
+        return MiniMessage.miniMessage().serialize(component);
+    }
+
+    public static @NotNull List<String> toMiniMessage(@NotNull List<Component> componentList) {
+        return componentList.stream().map(AdventureUtils::toMiniMessage).collect(Collectors.toList());
+    }
+
+    public static @NotNull String toPlainText(@NotNull Component component) {
+        return PlainTextComponentSerializer.plainText().serialize(component);
+    }
+
+    public static @NotNull List<String> toPlainText(@NotNull List<Component> componentList) {
+        return componentList.stream().map(AdventureUtils::toPlainText).collect(Collectors.toList());
+    }
+
+    public static @NotNull String stripTags(@NotNull String mini) {
+        return MiniMessage.miniMessage().stripTags(mini);
+    }
+
+    public static @NotNull List<String> stripTags(@NotNull List<String> miniList) {
+        return miniList.stream().map(AdventureUtils::stripTags).collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
Now you can use the [MiniMessage](https://docs.adventure.kyori.net/minimessage/index.html) formatting to modify your menu items!

New modifiers of item:

- `mini-name` / `adventure-name` / `name$`
- `mini-lore` / `adventure-lore` / `lore$`

The changes require Paper >=1.18.

I guess it's kinda a "new" addon as it requires recent version of Paper or its forks. But the provided feature is quite modern and powerful especially if the server is heavily using resourcepack (and the custom fonts, which the MiniMessage formatting can easily handle it).

Anyway, if anyone wanted to use MiniMessage formatting for their menu items they could just compile it on their own